### PR TITLE
Add /EHsc for MSVC to fix C4530 warning-as-error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /nologo /bigobj /Zc:__STDC__ /Zc:preprocessor /permissive- /utf-8")
+  # /EHsc enables C++ exception unwind semantics (required for std::string, iostreams, etc.)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /nologo /bigobj /EHsc /Zc:__STDC__ /Zc:preprocessor /permissive- /utf-8")
 endif()
 
 


### PR DESCRIPTION
## Summary

Enable `/EHsc` for MSVC builds so that C++ exception handling has proper unwind semantics and the MSVC warning C4530 is not emitted (and then promoted to an error by `/WX`).

## Background

On Windows with MSVC, Triton (and the Python extension) is built with `/WX`, so warnings are treated as errors. When compiling sources that use standard C++ exceptions and iostream/string facilities (via pybind11 and the STL), MSVC emits:

> warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc

Because `/WX` is active, this becomes:

> error C2220: the following warning is treated as an error

This was observed when building from `release/3.6.x-windows` in a Windows 11 / MSVC 19.44 environment, affecting files such as:

- `third_party/nvidia/triton_nvidia.cc`
- `python/src/main.cc`, `specialize.cc`, `interpreter.cc`, `linear_layout.cc`, `llvm.cc`, `gluon_ir.cc`, `passes.cc`, `ir.cc`

and standard headers like `<string>` and `__msvc_ostream.hpp`.

## Change

In the MSVC branch of `CMakeLists.txt` we now add `/EHsc` to `CMAKE_CXX_FLAGS`:

```cmake
if(NOT MSVC)
  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17")
else()
  # /EHsc enables C++ exception unwind semantics (required for std::string, iostreams, etc.)
  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /nologo /bigobj /EHsc /Zc:__STDC__ /Zc:preprocessor /permissive- /utf-8")
endif()
```

This is the standard flag combination for C++ exception handling on MSVC and matches what many CMake-based C++ projects do on Windows.

## Impact

- Fixes the C4530/C2220 warning-as-error build failures on Windows.
- Change is MSVC-only; non-MSVC toolchains are unaffected.
- No change in behavior for platforms where exceptions are already correctly configured.


Made with [Cursor](https://cursor.com)