### PR TITLE
Find `clang-cl.exe` from TheRock wheels

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -25,7 +25,7 @@ def get_cc():
     cc = os.environ.get("CC")
     if cc is None:
         # clang-cl from TheRock ROCm wheels (handles HIP C headers that mix C/C++ constructs)
-        cc = os.path.join(sysconfig.get_path("purelib"), "_rocm_sdk_core", "lib", "llvm", "bin", "clang-cl.exe")
+        cc = os.path.join(sysconfig.get_path("platlib"), "_rocm_sdk_core", "lib", "llvm", "bin", "clang-cl.exe")
         if not os.path.exists(cc):
             cc = None
     if cc is None:


### PR DESCRIPTION
This solves the issue where MSVC is unable to compile `hip_utils.c` because the HIP headers have C++ constructs like templates etc. `clang-cl.exe` is included in every TheRock distribution.

Fixes #4 