### PR TITLE
[AMD] Fix and skip a number of tests that were failing/unsupported on RDNA3

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna4
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4
 
 
 def matching_int(dtype):
@@ -289,8 +289,8 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
             return
-        if src_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4()):
-            pytest.skip(f"{src_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
+        if src_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna3() or is_hip_rdna4()):
+            pytest.skip(f"{src_dtype} is not supported on AMDGPU CDNA2, RDNA3 and RDNA4")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
     stuff = {
@@ -336,8 +336,8 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU CDNA3")
 
     if is_hip():
-        if dst_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4()):
-            pytest.skip(f"{dst_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
+        if dst_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna3() or is_hip_rdna4()):
+            pytest.skip(f"{dst_dtype} is not supported on AMDGPU CDNA2, RDNA3 and RDNA4")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)
     stuff = {

--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -19,14 +19,54 @@ if is_cuda():
         return ["cuda"]
 
 elif is_hip():
-    from triton.backends.amd.driver import include_dirs, _get_path_to_hip_runtime_dylib
+    from triton.backends.amd.driver import include_dirs
+
+    if os.name == "nt":
+        from triton.windows_utils import find_hip
 
     def library_dirs():
-        hip_runtime_dylib = _get_path_to_hip_runtime_dylib()
-        return [os.path.dirname(hip_runtime_dylib)]
+        if os.name == "nt":
+            _, _, lib_dirs = find_hip()
+            return lib_dirs
+        from triton.backends.amd.driver import _get_path_to_hip_runtime_dylib
+        return [os.path.dirname(_get_path_to_hip_runtime_dylib())]
 
     def library_names():
         return ["amdhip64"]
+
+
+def _find_cc():
+    """Find a C compiler. On HIP/Windows, uses clang-cl from the ROCm SDK
+    because MSVC's C mode cannot compile HIP headers with C++ constructs."""
+    if os.name == "nt" and is_hip():
+        _, _, lib_dirs = find_hip()
+        if lib_dirs:
+            clang_cl = os.path.join(os.path.dirname(lib_dirs[0]), "lib", "llvm", "bin", "clang-cl.exe")
+            if os.path.exists(clang_cl):
+                return clang_cl
+    return "cl"
+
+
+def _find_lib():
+    """Find a librarian tool. On HIP/Windows, uses llvm-lib from the ROCm SDK."""
+    if os.name == "nt" and is_hip():
+        _, _, lib_dirs = find_hip()
+        if lib_dirs:
+            llvm_lib = os.path.join(os.path.dirname(lib_dirs[0]), "lib", "llvm", "bin", "llvm-lib.exe")
+            if os.path.exists(llvm_lib):
+                return llvm_lib
+    return "lib"
+
+
+def _make_run_env(tmp_dir):
+    """Create environment for running AOT test executables."""
+    env = os.environ.copy()
+    if os.name == "nt":
+        extra_dirs = [tmp_dir] + library_dirs()
+        env["PATH"] = ";".join(extra_dirs) + ";" + env.get("PATH", "")
+    else:
+        env["LD_LIBRARY_PATH"] = tmp_dir
+    return env
 
 
 kernel_utils_src = """
@@ -156,15 +196,15 @@ def gen_kernel_library(dir, libname):
         libname = libname.lstrip("lib")
         libname = libname.replace(".so", ".lib")
 
+        cc = _find_cc()
         c_files = glob.glob(os.path.join(dir, "*.c"))
-        command = ["cl", *c_files, "/nologo", "/utf-8", "/c"]
+        command = [cc, *c_files, "/nologo", "/utf-8", "/c"]
         command += [f"/I{x}" for x in include_dirs if x is not None]
         subprocess.run(command, check=True, cwd=dir)
 
+        lib_tool = _find_lib()
         obj_files = glob.glob(os.path.join(dir, "*.obj"))
-        command = ["lib", *obj_files, "/nologo"]
-        command += [f"/LIBPATH:{x}" for x in library_dirs()]
-        command += ["cuda.lib", f"/OUT:{libname}"]
+        command = [lib_tool, *obj_files, "/nologo", f"/OUT:{libname}"]
         subprocess.run(command, check=True, cwd=dir)
     else:
         c_files = glob.glob(os.path.join(dir, "*.c"))
@@ -294,11 +334,12 @@ int main(int argc, char **argv) {{
         file.write(src)
 
     if os.name == "nt":
-        command = ["cl", "test.c", "/nologo", "/utf-8"]
+        cc = _find_cc()
+        command = [cc, "test.c", "/nologo", "/utf-8"]
         command += [f"/I{x}" for x in include_dirs if x is not None]
         command += ["/link"]
         command += [f"/LIBPATH:{x}" for x in library_dirs()]
-        command += [x for x in library_names()]
+        command += [f"{x}.lib" for x in library_names()]
         command += [f"/LIBPATH:{dir}", "kernel.lib", f"/OUT:{exe}.exe"]
     else:
         command = ["gcc", "test.c"]
@@ -430,8 +471,7 @@ def test_compile_link_matmul_no_specialization():
         a, b, a_path, b_path, c_path = generate_matmul_test_data(tmp_dir, M, N, K)
 
         # run test case
-        env = os.environ.copy()
-        env["LD_LIBRARY_PATH"] = tmp_dir
+        env = _make_run_env(tmp_dir)
         if os.name == "nt":
             exe = "test.exe"
         else:
@@ -468,8 +508,7 @@ def test_compile_link_matmul():
         a, b, a_path, b_path, c_path = generate_matmul_test_data(tmp_dir, M, N, K)
 
         # run test case
-        env = os.environ.copy()
-        env["LD_LIBRARY_PATH"] = tmp_dir
+        env = _make_run_env(tmp_dir)
         if os.name == "nt":
             exe = "test.exe"
         else:
@@ -507,8 +546,7 @@ def test_launcher_has_no_available_kernel():
         a, b, a_path, b_path, c_path = generate_matmul_test_data(tmp_dir, M, N, K)
 
         # run test case
-        env = os.environ.copy()
-        env["LD_LIBRARY_PATH"] = tmp_dir
+        env = _make_run_env(tmp_dir)
         if os.name == "nt":
             exe = "test.exe"
         else:
@@ -563,8 +601,7 @@ def test_compile_link_autotune_matmul():
             test_name = f"test_{algo_id}"
             gen_test_bin(tmp_dir, M, N, K, exe=test_name, algo_id=algo_id)
 
-            env = os.environ.copy()
-            env["LD_LIBRARY_PATH"] = tmp_dir
+            env = _make_run_env(tmp_dir)
             if os.name == "nt":
                 exe = f"{test_name}.exe"
             else:

--- a/python/triton/windows_utils.py
+++ b/python/triton/windows_utils.py
@@ -403,3 +403,26 @@ def find_cuda() -> tuple[Optional[str], list[str], list[str]]:
 
     warnings.warn("Failed to find CUDA.")
     return None, [], []
+
+
+@functools.lru_cache
+def find_hip() -> tuple[Optional[str], list[str], list[str]]:
+    """Find HIP SDK paths (bin, include dirs, lib dirs) from ROCm SDK wheels."""
+    try:
+        import rocm_sdk
+        paths = rocm_sdk.find_libraries("amdhip64")
+        if paths:
+            bin_dir = str(paths[0].parent)
+            root = str(paths[0].parent.parent)
+            inc_dir = os.path.join(root, "include")
+            lib_dir = os.path.join(root, "lib")
+            inc_dirs = [inc_dir] if os.path.isdir(inc_dir) else []
+            lib_dirs = [bin_dir]
+            if os.path.isdir(lib_dir):
+                lib_dirs.append(lib_dir)
+            return bin_dir, inc_dirs, lib_dirs
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    warnings.warn("Failed to find ROCm/HIP.")
+    return None, [], []

--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -46,7 +46,11 @@ class HipblasLtInstance {
       const hipblasLtMatrixLayout_t, void *, const hipblasLtMatrixLayout_t,
       const hipblasLtMatmulAlgo_t *, void *, size_t, hipStream_t);
 
+#ifdef _WIN32
+  static constexpr const char *name = "libhipblaslt.dll";
+#else
   static constexpr const char *name = "libhipblaslt.so";
+#endif
 
   hipblasLtCreate_t hipblasLtCreate;
   hipblasLtDestroy_t hipblasLtDestroy;


### PR DESCRIPTION
Fix Windows HIP test failures: hipblaslt DLL, AOT toolchain, FP8 skips, and find_hip
- hipblas_instance.h: Add #ifdef _WIN32 to use libhipblaslt.dll instead of .so
- test_aot.py: Use clang-cl/llvm-lib from ROCm SDK instead of MSVC cl/lib
  (MSVC C mode rejects C++ constructs in HIP headers), add HIP lib dir for
  import libraries, add DLL dirs to PATH for runtime
- test_conversions.py: Skip FP8 conversion tests (float8e4b8, float8e5b16,
  float8e5, float8e4nv) on RDNA3 which doesn't support these types
- windows_utils.py: Add find_hip() and find_gpu() functions, remove spurious
  "Failed to find CUDA" warning on HIP-only systems
