### PR TITLE
[AMD] Accept versioned amdhip64 DLL names in TRITON_LIBHIP_PATH

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -113,7 +113,7 @@ def _get_path_to_hip_runtime_dylib():
 
     # If we are told explicitly what HIP runtime dynamic library to use, obey that.
     if env_libhip_path := knobs.amd.libhip_path:
-        if env_libhip_path.endswith(lib_name) and os.path.exists(env_libhip_path):
+        if os.path.exists(env_libhip_path) and ("amdhip64" in os.path.basename(env_libhip_path)):
             return env_libhip_path
         raise RuntimeError(f"TRITON_LIBHIP_PATH '{env_libhip_path}' does not point to a valid {lib_name}")
 


### PR DESCRIPTION
Relax the TRITON_LIBHIP_PATH validation to accept any filename containing "amdhip64" (e.g. amdhip64_7.dll) instead of requiring an exact match on "amdhip64.dll". This allows hip-remote's proxy DLL to be loaded via TRITON_LIBHIP_PATH, ensuring Triton shares the same DLL instance and worker connection as PyTorch.