### PR TITLE
Fix `alloca` undeclared function error on Windows

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -8,8 +8,8 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-#include <windows.h>
 #include <malloc.h>
+#include <windows.h>
 // Windows compatibility layer for dlopen/dlsym/dlclose/dlerror
 #define RTLD_NOW 0
 #define RTLD_LAZY 0


### PR DESCRIPTION
Adding missing `<malloc.h>` include to enable `alloca()` function support on Windows.

This fixes the following error while running `python setup.py --use-pytorch-flash-attention` on `ComfyUI`:

```
\\?\C:\Users\master\AppData\Local\Temp\tmpzrtyhpgp\hip_utils.c(1078,39): error: call to undeclared function 'alloca';
      ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1078 |   PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
      |                                       ^
\\?\C:\Users\master\AppData\Local\Temp\tmpzrtyhpgp\hip_utils.c(1078,26): warning: cast to 'PyObject **'
      (aka 'struct _object **') from smaller integer type 'int' [-Wint-to-pointer-cast]
 1078 |   PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
\\?\C:\Users\master\AppData\Local\Temp\tmpzrtyhpgp\hip_utils.c(1089,19): warning: cast to 'void **' from smaller integer
      type 'int' [-Wint-to-pointer-cast]
 1089 |   void **params = (void **)alloca(num_params * sizeof(void *));
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
\\?\C:\Users\master\AppData\Local\Temp\tmpzrtyhpgp\hip_utils.c(1102,24): error: incompatible integer to pointer
      conversion assigning to 'void *' from 'int' [-Wint-conversion]
 1102 |     params[params_idx] = alloca(extractor.size);
      |                        ^ ~~~~~~~~~~~~~~~~~~~~~~
\\?\C:\Users\master\AppData\Local\Temp\tmpzrtyhpgp\hip_utils.c(1108,22): error: incompatible integer to pointer
      conversion assigning to 'void *' from 'int' [-Wint-conversion]
 1108 |   params[params_idx] = alloca(sizeof(void *));
      |                      ^ ~~~~~~~~~~~~~~~~~~~~~~
\\?\C:\Users\master\AppData\Local\Temp\tmpzrtyhpgp\hip_utils.c(1113,22): error: incompatible integer to pointer
      conversion assigning to 'void *' from 'int' [-Wint-conversion]
 1113 |   params[params_idx] = alloca(sizeof(void *));
      |                      ^ ~~~~~~~~~~~~~~~~~~~~~~
2 warnings and 4 errors generated.
```