### PR TITLE
Fix HIP runtime DLL context sharing on Windows

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -17,10 +17,15 @@
 static char dlerror_buf[512];
 static inline void *dlopen(const char *filename, int flags) {
   (void)flags;
-  HMODULE h = LoadLibraryA(filename);
+  // Reuse HIP DLL if already loaded to share GPU memory context
+  const char *basename = strrchr(filename, '\\') + 1;
+  HMODULE h = GetModuleHandleA(basename);
   if (!h) {
-    snprintf(dlerror_buf, sizeof(dlerror_buf),
-             "LoadLibrary failed with error %lu", GetLastError());
+    h = LoadLibraryA(filename);
+    if (!h) {
+      snprintf(dlerror_buf, sizeof(dlerror_buf),
+               "LoadLibrary failed with error %lu", GetLastError());
+    }
   }
   return (void *)h;
 }


### PR DESCRIPTION
Fix for `Pointer argument cannot be accessed from Triton (cpu tensor?)` error while running ComfyUI with flash attention and sage attention on Windows. 

The Windows `dlopen()` wrapper uses `LoadLibraryA()` which loads a new HIP DLL instance, creating a separate HIP context. GPU memory allocated by PyTorch in one HIP context is invisible to Triton's separate HIP context, causing `hipPointerGetAttribute()` to fail.
Modify `dlopen()` to first check for an already-loaded HIP DLL using `GetModuleHandleA()` before falling back to `LoadLibraryA()`. This ensures Triton reuses PyTorch's HIP DLL instance and shares the same GPU memory context.