### PR TITLE
Fix finding bundled cuda for editable builds

### DIFF
--- a/python/triton/windows_utils.py
+++ b/python/triton/windows_utils.py
@@ -359,7 +359,7 @@ def find_cuda_env() -> tuple[Optional[str], list[str], list[str]]:
 
 
 def find_cuda_bundled() -> tuple[Optional[str], list[str], list[str]]:
-    cuda_base_path = (Path(sysconfig.get_paths()["platlib"]) / "triton" / "backends" / "nvidia")
+    cuda_base_path = Path(__file__).parent / "backends" / "nvidia"
     return check_and_find_cuda(cuda_base_path)
 
 


### PR DESCRIPTION
Previously, `(Path(sysconfig.get_paths()["platlib"]) / "triton" / "backends" / "nvidia")` resolved to the triton package in `site-packages`. This introduces issues when installing triton from source in editable mode with `pip install -e .`. In that case, triton is not in the `site-packages` but rather somewhere on the system.

With this fix, if we search for bundled cuda, it correctly resolves the paths regardless of the way that triton is installed.

This fix resolves additional "CUDA not found" warnings tracked by #6 .

