### PR TITLE
Support lazy annotation in Python 3.14

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1607,8 +1607,9 @@ def _resolve_aggregate_fields(cls):
         all_annotations.update(getattr(base, "__annotations__", {}))
         all_defaults.update(getattr(base, "__aggregate_defaults__", {}))
 
-    # Add cls's own fields, resolving string annotations via typing.get_type_hints.
-    own_names = cls.__dict__.get("__annotations__", {})
+    # Add cls's own fields, materializing lazy annotations and resolving string
+    # annotations via typing.get_type_hints.
+    own_names = inspect.get_annotations(cls, eval_str=False)
     hints = typing.get_type_hints(cls)
     for name in own_names:
         all_annotations[name] = hints[name]


### PR DESCRIPTION
I was a bit surprised that previously Triton did not pass all unit tests on Python 3.14 even though it has released wheels for Python 3.14 . We need `inspect.get_annotations` to support lazy annotation in Python 3.14, see https://peps.python.org/pep-0649/ .

I'll make a PR to the upstream Triton repo.

After this PR, on `main-windows` branch, the only failing test on gfx1151 is `language/test_core.py::test_load_scope_sem_coop_grid_cta_one`, which is expectedly unsupported.