### PR TITLE
Fix hardcoded Linux library names and env vars in C/C++ error messages

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -48,6 +48,12 @@ static inline const char *dlerror(void) {
 #include <dlfcn.h>
 #endif
 
+#ifdef _WIN32
+#define HIP_LIB_NAME "amdhip64.dll"
+#else
+#define HIP_LIB_NAME "libamdhip64.so"
+#endif
+
 // Include shared TDM utilities
 #include "TDMCommon.h"
 
@@ -361,7 +367,7 @@ static int checkDriverVersion(void *lib) {
   error = dlerror();
   if (error) {
     PyErr_SetString(PyExc_RuntimeError,
-                    "cannot query 'hipDriverGetVersion' from libamdhip64.so");
+                    "cannot query 'hipDriverGetVersion' from " HIP_LIB_NAME);
     dlclose(lib);
     return -1;
   }
@@ -376,9 +382,9 @@ static int checkDriverVersion(void *lib) {
     const int hipPatchVersion =
         TRITON_HIP_DRIVER_EXTRACT_PATCH_VERSION(hipVersion);
     snprintf(msgBuff, sizeof(msgBuff),
-             "libamdhip64 version %d.%d.%d is not supported! Required major "
+             "%s version %d.%d.%d is not supported! Required major "
              "version is >=%d.",
-             hipMajVersion, hipMinVersion, hipPatchVersion,
+             HIP_LIB_NAME, hipMajVersion, hipMinVersion, hipPatchVersion,
              TRITON_HIP_DRIVER_REQ_MAJOR_VERSION);
     PyErr_SetString(PyExc_RuntimeError, msgBuff);
     dlclose(lib);
@@ -404,7 +410,7 @@ bool initSymbolTable() {
   }
 
   if (!lib) {
-    PyErr_SetString(PyExc_RuntimeError, "cannot open libamdhip64.so");
+    PyErr_SetString(PyExc_RuntimeError, "cannot open " HIP_LIB_NAME);
     return false;
   }
 
@@ -423,7 +429,7 @@ bool initSymbolTable() {
   error = dlerror();
   if (error) {
     PyErr_SetString(PyExc_RuntimeError,
-                    "cannot query 'hipGetProcAddress' from libamdhip64.so");
+                    "cannot query 'hipGetProcAddress' from " HIP_LIB_NAME);
     dlclose(lib);
     return false;
   }
@@ -439,7 +445,7 @@ bool initSymbolTable() {
   if (required && status != hipSuccess) {                                      \
     PyErr_SetString(PyExc_RuntimeError,                                        \
                     "cannot get address for '" #hipSymbolName                  \
-                    "' from libamdhip64.so");                                  \
+                    "' from " HIP_LIB_NAME);                                   \
     dlclose(lib);                                                              \
     return false;                                                              \
   }

--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -85,7 +85,12 @@ class HipblasLtInstance {
     if (dylibHandle == nullptr) {
       throw std::runtime_error("Could not find `" + std::string(name) +
                                "`. Make sure it is in your "
-                               "LD_LIBRARY_PATH.");
+#ifdef _WIN32
+                               "PATH."
+#else
+                               "LD_LIBRARY_PATH."
+#endif
+      );
     }
     dlerror(); // Clear any existing error
 

--- a/third_party/nvidia/include/cublas_instance.h
+++ b/third_party/nvidia/include/cublas_instance.h
@@ -80,7 +80,12 @@ private:
     if (dylibHandle == nullptr) {
       throw std::runtime_error("Could not find `" + std::string(name) +
                                "`. Make sure it is in your "
-                               "LD_LIBRARY_PATH.");
+#ifdef _WIN32
+                               "PATH."
+#else
+                               "LD_LIBRARY_PATH."
+#endif
+      );
     }
     dlerror(); // Clear any existing error
 

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -81,9 +81,15 @@ public:
     dylibHandle = dlopen("libcuda.so.1", RTLD_NOLOAD | RTLD_LAZY);
 #endif
     if (dylibHandle == nullptr) {
+#ifdef _WIN32
+      throw std::runtime_error(
+          "Could not find an already-loaded `nvcuda.dll`. Initialize "
+          "Triton's NVIDIA runtime before using this helper.");
+#else
       throw std::runtime_error(
           "Could not find an already-loaded `libcuda.so.1`. Initialize "
           "Triton's NVIDIA runtime before using this helper.");
+#endif
     }
     cuMemAlloc = loadSymbol<cuMemAlloc_t>("cuMemAlloc_v2");
     cuMemFree = loadSymbol<cuMemFree_t>("cuMemFree_v2");


### PR DESCRIPTION
Fix hardcoded Linux library and environment variable names in backend error messages so Windows users see platform-appropriate diagnostics.

This addresses part of issue triton-lang/triton-windows#8 by correcting AMD/NVIDIA driver and BLAS error text without changing runtime behavior.

cc @tvukovic-amd