### PR TITLE
Add FormatMessage to C backend Windows error handling

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -15,6 +15,19 @@
 #define RTLD_LAZY 0
 #define RTLD_LOCAL 0
 static char dlerror_buf[512];
+// Format a Windows error code into a human-readable message.
+static void win32_format_error(char *buf, size_t bufsize, const char *context,
+                               DWORD err) {
+  char msg[256] = {0};
+  DWORD len =
+      FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                     NULL, err, 0, msg, sizeof(msg), NULL);
+  // Strip trailing \r\n
+  while (len > 0 && (msg[len - 1] == '\r' || msg[len - 1] == '\n'))
+    msg[--len] = '\0';
+  snprintf(buf, bufsize, "%s: %s (error %lu)", context, msg,
+           (unsigned long)err);
+}
 static inline void *dlopen(const char *filename, int flags) {
   (void)flags;
   // Reuse HIP DLL if already loaded to share GPU memory context
@@ -23,8 +36,11 @@ static inline void *dlopen(const char *filename, int flags) {
   if (!h) {
     h = LoadLibraryA(filename);
     if (!h) {
-      snprintf(dlerror_buf, sizeof(dlerror_buf),
-               "LoadLibrary failed with error %lu", GetLastError());
+      char context[256];
+      snprintf(context, sizeof(context), "LoadLibrary failed for '%s'",
+               filename);
+      win32_format_error(dlerror_buf, sizeof(dlerror_buf), context,
+                         GetLastError());
     }
   }
   return (void *)h;
@@ -32,9 +48,11 @@ static inline void *dlopen(const char *filename, int flags) {
 static inline void *dlsym(void *handle, const char *symbol) {
   void *p = (void *)GetProcAddress((HMODULE)handle, symbol);
   if (!p) {
-    snprintf(dlerror_buf, sizeof(dlerror_buf),
-             "GetProcAddress failed for %s with error %lu", symbol,
-             GetLastError());
+    char context[256];
+    snprintf(context, sizeof(context), "GetProcAddress failed for '%s'",
+             symbol);
+    win32_format_error(dlerror_buf, sizeof(dlerror_buf), context,
+                       GetLastError());
   }
   return p;
 }

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -25,8 +25,8 @@ static void win32_format_error(char *buf, size_t bufsize, const char *context,
   // Strip trailing \r\n
   while (len > 0 && (msg[len - 1] == '\r' || msg[len - 1] == '\n'))
     msg[--len] = '\0';
-  snprintf(buf, bufsize, "%s: %s (error %lu)", context, msg,
-           (unsigned long)err);
+  snprintf(buf, bufsize, "%s: %s (error %lu)", context,
+           len ? msg : "Unknown error", (unsigned long)err);
 }
 static inline void *dlopen(const char *filename, int flags) {
   (void)flags;

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -369,21 +369,37 @@ typedef CUresult (*cuLaunchKernelEx_t)(const CUlaunchConfig *config,
     return funcHandle;                                                         \
   }
 #else
+/* Format a Windows error code into a human-readable message. */
+static void win32_format_error(char *buf, size_t bufsize, const char *context,
+                               DWORD err) {
+  char msg[256] = {0};
+  DWORD len =
+      FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                     NULL, err, 0, msg, sizeof(msg), NULL);
+  while (len > 0 && (msg[len - 1] == '\r' || msg[len - 1] == '\n'))
+    msg[--len] = '\0';
+  snprintf(buf, bufsize, "%s: %s (error %lu)", context, msg,
+           (unsigned long)err);
+}
 #define defineGetFunctionHandle(name, symbolName)                              \
   static symbolName##_t name() {                                               \
     /* Open the shared library */                                              \
     HMODULE handle = LoadLibraryA("nvcuda.dll");                               \
     if (!handle) {                                                             \
-      PyErr_SetString(PyExc_RuntimeError, "Failed to open nvcuda.dll");        \
+      char errBuf[512];                                                        \
+      win32_format_error(errBuf, sizeof(errBuf), "Failed to open nvcuda.dll",  \
+                         GetLastError());                                      \
+      PyErr_SetString(PyExc_RuntimeError, errBuf);                             \
       return NULL;                                                             \
     }                                                                          \
     symbolName##_t funcHandle =                                                \
         (symbolName##_t)GetProcAddress((HMODULE)handle, #symbolName);          \
-    /* Check for errors */                                                     \
-    long err = GetLastError();                                                 \
-    if (err) {                                                                 \
-      PyErr_SetString(PyExc_RuntimeError,                                      \
-                      "Failed to retrieve " #symbolName " from nvcuda.dll");   \
+    if (!funcHandle) {                                                         \
+      char errBuf[512];                                                        \
+      win32_format_error(errBuf, sizeof(errBuf),                               \
+                         "Failed to retrieve " #symbolName " from nvcuda.dll", \
+                         GetLastError());                                      \
+      PyErr_SetString(PyExc_RuntimeError, errBuf);                             \
       return NULL;                                                             \
     }                                                                          \
     return funcHandle;                                                         \

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -378,8 +378,8 @@ static void win32_format_error(char *buf, size_t bufsize, const char *context,
                      NULL, err, 0, msg, sizeof(msg), NULL);
   while (len > 0 && (msg[len - 1] == '\r' || msg[len - 1] == '\n'))
     msg[--len] = '\0';
-  snprintf(buf, bufsize, "%s: %s (error %lu)", context, msg,
-           (unsigned long)err);
+  snprintf(buf, bufsize, "%s: %s (error %lu)", context,
+           len ? msg : "Unknown error", (unsigned long)err);
 }
 #define defineGetFunctionHandle(name, symbolName)                              \
   static symbolName##_t name() {                                               \


### PR DESCRIPTION
Add Windows `FormatMessage` handling to the AMD and NVIDIA C backend driver error paths so failed Win32 calls report useful system messages, with a fallback for unknown errors.

This helps address triton-lang/triton-windows#8 by improving Windows backend diagnostics without changing non-Windows behavior.Add win32_format_error() helper that uses FormatMessageA() to convert
Windows error codes into human-readable messages. Applied to the inline
dlopen/dlsym compat layer in the AMD backend and the defineGetFunctionHandle
macro in the NVIDIA backend.

Before: 'LoadLibrary failed with error 126'
After:  'LoadLibrary failed for "amdhip64.dll": The specified module could not be found. (error 126)'

Also fixes a bug in the NVIDIA backend where GetLastError() was called
unconditionally after GetProcAddress, potentially producing false-positive
errors. Now correctly checks if funcHandle is NULL first.

Addresses #8

cc @tvukovic-amd