### PR TITLE
Add Windows-specific error suggestions and debug logging

### DIFF
--- a/python/triton/experimental/gsan/_allocator.py
+++ b/python/triton/experimental/gsan/_allocator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import os
 from pathlib import Path
 from types import ModuleType
 
@@ -23,7 +24,7 @@ def _load_gsan_module() -> ModuleType:
         name="gsan_allocator",
         library_dirs=library_dirs(),
         include_dirs=include_dirs,
-        libraries=["libcuda.so.1"],
+        libraries=["cuda"] if os.name == "nt" else ["libcuda.so.1"],
     )
 
 

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -181,6 +181,10 @@ def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_di
 
 
 def _library_flag(lib: str) -> str:
+    if os.name == "nt":
+        if not lib.endswith(".lib"):
+            lib = lib + ".lib"
+        return lib
     # Match .so files with optional version numbers (e.g., .so, .so.1, .so.513.50.1)
     if re.search(r'\.so(\.\d+)*$', lib) or lib.endswith(".a"):
         return f"-l:{lib}"
@@ -241,7 +245,8 @@ def _compile_so(src: bytes, src_path: str, name: str, library_dirs: list[str] | 
             return _load_module_from_path(name, cache_path)
         except (RuntimeError, ImportError):
             log = logging.getLogger(__name__)
-            log.warning(f"Triton cache error: compiled module {name}.so could not be loaded")
+            ext = ".pyd" if os.name == "nt" else ".so"
+            log.warning(f"Triton cache error: compiled module {name}{ext} could not be loaded")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = normalize_path(tmpdir)

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -12,7 +12,20 @@ def _create_driver() -> DriverBase:
             raise RuntimeError(f"Unknown backend device '{selected}'. Available backends: {list(backends.keys())}")
         driver = backends[selected].driver
         if not driver.is_active():
-            raise RuntimeError(f"Backend device '{selected}' is not active.")
+            msg = f"Backend device '{selected}' is not active."
+            if os.name == "nt":
+                if selected == "hip":
+                    msg += ("\n\nOn Windows, ensure that:"
+                            "\n  - ROCm for Windows is installed (e.g. 'pip install rocm-sdk')"
+                            "\n  - 'amdhip64.dll' is on your PATH"
+                            "\n  - HIP_PATH environment variable is set to the HIP SDK root"
+                            "\n  - Your AMD GPU driver is up to date")
+                elif selected == "cuda":
+                    msg += ("\n\nOn Windows, ensure that:"
+                            "\n  - CUDA Toolkit is installed (https://developer.nvidia.com/cuda-downloads)"
+                            "\n  - 'nvcuda.dll' is on your PATH"
+                            "\n  - Your NVIDIA GPU driver is up to date")
+            raise RuntimeError(msg)
         return driver()
     else:
         active_drivers = [x.driver for x in backends.values() if x.driver.is_active()]

--- a/python/triton/windows_utils.py
+++ b/python/triton/windows_utils.py
@@ -185,7 +185,9 @@ def find_msvc(env_only: bool) -> tuple[Optional[str], list[str], list[str]]:
             )
 
     if not env_only:
-        warnings.warn("Failed to find MSVC.")
+        warnings.warn("Failed to find MSVC."
+                      " Install Visual Studio Build Tools (https://visualstudio.microsoft.com/downloads/)"
+                      " or set the CC environment variable to your C compiler.")
     return None, [], []
 
 
@@ -284,7 +286,9 @@ def find_winsdk(env_only: bool) -> tuple[list[str], list[str]]:
             )
 
     if not env_only:
-        warnings.warn("Failed to find Windows SDK.")
+        warnings.warn("Failed to find Windows SDK."
+                      " Install it via Visual Studio Installer or from"
+                      " https://developer.microsoft.com/windows/downloads/windows-sdk/")
     return [], []
 
 
@@ -313,7 +317,9 @@ def find_python() -> list[str]:
         if (python_lib_dir / f"python{version}.lib").exists():
             return [str(python_lib_dir)]
 
-    warnings.warn("Failed to find Python libs.")
+    warnings.warn("Failed to find Python libs."
+                  " Ensure you are using an official Python distribution"
+                  " and python3XX.lib exists in your Python installation.")
     return []
 
 
@@ -416,7 +422,9 @@ def find_cuda() -> tuple[Optional[str], list[str], list[str]]:
         if cuda_bin_path:
             return cuda_bin_path, cuda_inc_dirs, cuda_lib_dirs
 
-    warnings.warn("Failed to find CUDA.")
+    warnings.warn("Failed to find CUDA."
+                  " Install CUDA Toolkit (https://developer.nvidia.com/cuda-downloads)"
+                  " or set CUDA_HOME / CUDA_PATH environment variable.")
     return None, [], []
 
 
@@ -439,7 +447,9 @@ def find_hip() -> tuple[Optional[str], list[str], list[str]]:
     except (ImportError, ModuleNotFoundError):
         pass
 
-    warnings.warn("Failed to find ROCm/HIP.")
+    warnings.warn("Failed to find ROCm/HIP."
+                  " Install ROCm for Windows (https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/windows/howto_windows.html#)"
+                  " or set HIP_PATH environment variable.")
     return None, [], []
 
 

--- a/python/triton/windows_utils.py
+++ b/python/triton/windows_utils.py
@@ -447,9 +447,10 @@ def find_hip() -> tuple[Optional[str], list[str], list[str]]:
     except (ImportError, ModuleNotFoundError):
         pass
 
-    warnings.warn("Failed to find ROCm/HIP."
-                  " Install ROCm for Windows (https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/windows/howto_windows.html#)"
-                  " or set HIP_PATH environment variable.")
+    warnings.warn(
+        "Failed to find ROCm/HIP."
+        " Install ROCm for Windows (https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/windows/howto_windows.html#)"
+        " or set HIP_PATH environment variable.")
     return None, [], []
 
 

--- a/python/triton_kernels/triton_kernels/roofline.py
+++ b/python/triton_kernels/triton_kernels/roofline.py
@@ -1,4 +1,5 @@
 import ctypes
+import os
 import matplotlib.pyplot as plt
 import triton
 from triton._C.libtriton import nvidia, amd
@@ -67,7 +68,7 @@ def compute_roofline(*args, \
     perfs = []
     if verbose:
         print("=========================================")
-        print(f"{out_path   }...")
+        print(f"{out_path}...")
         print("=========================================")
     for val in intensity_proxy_values:
         perf = inject_proxy_and_call(val, args, kwargs)
@@ -90,14 +91,14 @@ def get_memset_tbps():
     stream0 = ctypes.c_void_p(0)
 
     if is_cuda():
-        libname = "libcuda.so"
+        libname = "nvcuda.dll" if os.name == "nt" else "libcuda.so"
         init_name = "cuInit"
         memset_name = "cuMemsetD8Async"
         memset_argtypes = [ctypes.c_uint64, ctypes.c_ubyte, ctypes.c_size_t, ctypes.c_void_p]
         dptr = ctypes.c_uint64(buf.data_ptr())
         value = ctypes.c_ubyte(0)
     elif is_hip():
-        libname = "libamdhip64.so"
+        libname = "amdhip64.dll" if os.name == "nt" else "libamdhip64.so"
         init_name = "hipInit"
         memset_name = "hipMemsetAsync"
         memset_argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t, ctypes.c_void_p]
@@ -116,7 +117,8 @@ def get_memset_tbps():
         init_fn(0)
 
     if not hasattr(lib, memset_name):
-        raise RuntimeError(f"{memset_name} not found in {libname}")
+        raise RuntimeError(f"{memset_name} not found in {libname}."
+                           " Ensure the correct GPU driver/runtime library is installed.")
 
     memset_fn = getattr(lib, memset_name)
     memset_fn.argtypes = memset_argtypes

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -220,7 +220,13 @@ def _get_path_to_hip_runtime_dylib():
             return common_install_path
         paths.append(common_install_path)
 
-    raise RuntimeError(f"cannot locate {lib_name} after attempted paths {paths}")
+    msg = f"cannot locate {lib_name} after attempted paths {paths}"
+    if _is_windows():
+        msg += ("\n\nOn Windows, ensure that:"
+                "\n  - ROCm for Windows is installed (e.g. 'pip install rocm-sdk')"
+                f"\n  - '{lib_name}' is on your PATH or HIP_PATH is set to the HIP SDK root"
+                f"\n  - Or set TRITON_LIBHIP_PATH to the full path of {lib_name}")
+    raise RuntimeError(msg)
 
 
 class HIPUtils(object):

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import os
 import subprocess
 import triton
@@ -9,6 +10,8 @@ from triton.runtime.build import compile_module_from_file
 from triton.runtime import _allocation
 from triton.backends.compiler import GPUTarget
 from triton.backends.driver import GPUDriver, decompose_descriptor, expand_signature, wrap_handle_tensordesc_impl
+
+logger = logging.getLogger(__name__)
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dirs = [os.path.join(dirname, "include")]
@@ -70,8 +73,8 @@ def _cuda_driver_is_active():
         candidates = ["libcuda.so.1"]
         try:
             candidates.extend([os.path.join(path, "libcuda.so.1") for path in libcuda_dirs()])
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to get libcuda dirs: %s", e)
         load_library = ctypes.CDLL
 
     libcuda = None
@@ -79,7 +82,8 @@ def _cuda_driver_is_active():
         try:
             libcuda = load_library(candidate)
             break
-        except OSError:
+        except OSError as e:
+            logger.debug("Failed to load %s: %s", candidate, e)
             continue
 
     if libcuda is None:


### PR DESCRIPTION
Adds Windows-specific diagnostics around Python-side build and backend loading failures, including clearer suggestions for compiler, CUDA/HIP, and driver-related setup issues.

This helps users diagnose common Windows setup failures while continuing the upstream Windows enablement work tracked in triton-lang/triton-windows#8.

cc @tvukovic-amd