### PR TITLE
Add CI support for Windows ARM64 and fix errors

### DIFF
--- a/.github/workflows/build-triton.yml
+++ b/.github/workflows/build-triton.yml
@@ -79,7 +79,7 @@ jobs:
             wheel_platform: win_amd64
           - architecture: arm64
             runner: windows-11-arm
-            msvc_arch: arm64_arm64
+            msvc_arch: arm64
             cibw_arch: ARM64
             cibw_build: cp3{11,12,13,14}
             cibw_pre_abi3_build: cp311

--- a/.github/workflows/build-triton.yml
+++ b/.github/workflows/build-triton.yml
@@ -64,9 +64,27 @@ jobs:
           "commit_sha=$(git rev-parse HEAD)" >> $Env:GITHUB_OUTPUT
 
   build-triton:
-    name: Build ${{ inputs.git_tag }} @ ${{ needs.resolve-ref.outputs.commit_sha }}
+    name: Build ${{ inputs.git_tag }} (${{ matrix.architecture }}) @ ${{ needs.resolve-ref.outputs.commit_sha }}
     needs: resolve-ref
-    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: x64
+            runner: windows-2022
+            msvc_arch: x64
+            cibw_arch: AMD64
+            cibw_build: cp3{10,11,12,13,14}
+            cibw_pre_abi3_build: cp3{10,11}
+            wheel_platform: win_amd64
+          - architecture: arm64
+            runner: windows-11-arm
+            msvc_arch: arm64_arm64
+            cibw_arch: ARM64
+            cibw_build: cp3{11,12,13,14}
+            cibw_pre_abi3_build: cp311
+            wheel_platform: win_arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       id-token: write
@@ -84,8 +102,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          architecture: ${{ matrix.architecture }}
 
       - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.msvc_arch }}
 
       - name: Build wheels
         shell: powershell
@@ -97,6 +118,10 @@ jobs:
           TRITON_REL_BUILD_WITH_ASSERTS: ${{ inputs.triton_rel_build_with_asserts }}
           IS_PYTHON_ABI3: ${{ inputs.is_python_abi3 }}
           CIBW_BUILD_OVERRIDE: ${{ inputs.cibw_build_override }}
+          CIBW_ARCHS: ${{ matrix.cibw_arch }}
+          CIBW_DEFAULT_BUILD: ${{ matrix.cibw_build }}
+          CIBW_PRE_ABI3_BUILD: ${{ matrix.cibw_pre_abi3_build }}
+          WHEEL_PLATFORM: ${{ matrix.wheel_platform }}
         run: |
           # Get-ChildItem Env:
           # (Get-WmiObject Win32_Processor).Name
@@ -125,10 +150,10 @@ jobs:
             }
             else
             {
-              $Env:CIBW_BUILD = "cp3{10,11}-win_amd64"
+              $Env:CIBW_BUILD = "$Env:CIBW_PRE_ABI3_BUILD-$Env:WHEEL_PLATFORM"
               cibuildwheel .
 
-              $Env:CIBW_BUILD = "cp312-win_amd64"
+              $Env:CIBW_BUILD = "cp312-$Env:WHEEL_PLATFORM"
               $Env:TRITON_STABLE_ABI = "ON"
               cibuildwheel .
             }
@@ -141,7 +166,7 @@ jobs:
             }
             else
             {
-              $Env:CIBW_BUILD = "cp3{10,11,12,13,14}-win_amd64"
+              $Env:CIBW_BUILD = "$Env:CIBW_DEFAULT_BUILD-$Env:WHEEL_PLATFORM"
             }
 
             if (Test-Path -Path setup.py)
@@ -160,35 +185,36 @@ jobs:
 
       # Currently actions/upload-artifact only supports uploading one file at a time when archive is disabled
       - uses: actions/upload-artifact@v7
+        if: ${{ matrix.architecture == 'x64' }}
         with:
-          path: triton-windows/wheelhouse/*-cp310-cp310-win_amd64.whl
+          path: triton-windows/wheelhouse/*-cp310-cp310-${{ matrix.wheel_platform }}.whl
           archive: false
 
       - uses: actions/upload-artifact@v7
         with:
-          path: triton-windows/wheelhouse/*-cp311-cp311-win_amd64.whl
+          path: triton-windows/wheelhouse/*-cp311-cp311-${{ matrix.wheel_platform }}.whl
           archive: false
 
       - uses: actions/upload-artifact@v7
         if: ${{ inputs.is_python_abi3 }}
         with:
-          path: triton-windows/wheelhouse/*-cp312-abi3-win_amd64.whl
+          path: triton-windows/wheelhouse/*-cp312-abi3-${{ matrix.wheel_platform }}.whl
           archive: false
 
       - uses: actions/upload-artifact@v7
         if: ${{ !inputs.is_python_abi3 }}
         with:
-          path: triton-windows/wheelhouse/*-cp312-cp312-win_amd64.whl
+          path: triton-windows/wheelhouse/*-cp312-cp312-${{ matrix.wheel_platform }}.whl
           archive: false
 
       - uses: actions/upload-artifact@v7
         if: ${{ !inputs.is_python_abi3 }}
         with:
-          path: triton-windows/wheelhouse/*-cp313-cp313-win_amd64.whl
+          path: triton-windows/wheelhouse/*-cp313-cp313-${{ matrix.wheel_platform }}.whl
           archive: false
 
       - uses: actions/upload-artifact@v7
         if: ${{ !inputs.is_python_abi3 }}
         with:
-          path: triton-windows/wheelhouse/*-cp314-cp314-win_amd64.whl
+          path: triton-windows/wheelhouse/*-cp314-cp314-${{ matrix.wheel_platform }}.whl
           archive: false

--- a/.github/workflows/build-triton.yml
+++ b/.github/workflows/build-triton.yml
@@ -74,15 +74,15 @@ jobs:
             runner: windows-2022
             msvc_arch: x64
             cibw_arch: AMD64
-            cibw_build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
-            cibw_pre_abi3_build: "cp310-* cp311-*"
+            cibw_build: cp3{10,11,12,13,14}
+            cibw_pre_abi3_build: cp3{10,11}
             wheel_platform: win_amd64
           - architecture: arm64
             runner: windows-11-arm
             msvc_arch: arm64
             cibw_arch: ARM64
-            cibw_build: "cp311-* cp312-* cp313-* cp314-*"
-            cibw_pre_abi3_build: "cp311-*"
+            cibw_build: cp3{11,12,13,14}
+            cibw_pre_abi3_build: cp311
             wheel_platform: win_arm64
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -150,7 +150,7 @@ jobs:
             }
             else
             {
-              $Env:CIBW_BUILD = $Env:CIBW_PRE_ABI3_BUILD
+              $Env:CIBW_BUILD = "$Env:CIBW_PRE_ABI3_BUILD-$Env:WHEEL_PLATFORM"
               cibuildwheel .
 
               $Env:CIBW_BUILD = "cp312-$Env:WHEEL_PLATFORM"
@@ -166,7 +166,7 @@ jobs:
             }
             else
             {
-              $Env:CIBW_BUILD = $Env:CIBW_DEFAULT_BUILD
+              $Env:CIBW_BUILD = "$Env:CIBW_DEFAULT_BUILD-$Env:WHEEL_PLATFORM"
             }
 
             if (Test-Path -Path setup.py)

--- a/.github/workflows/build-triton.yml
+++ b/.github/workflows/build-triton.yml
@@ -74,15 +74,15 @@ jobs:
             runner: windows-2022
             msvc_arch: x64
             cibw_arch: AMD64
-            cibw_build: cp3{10,11,12,13,14}
-            cibw_pre_abi3_build: cp3{10,11}
+            cibw_build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+            cibw_pre_abi3_build: "cp310-* cp311-*"
             wheel_platform: win_amd64
           - architecture: arm64
             runner: windows-11-arm
             msvc_arch: arm64
             cibw_arch: ARM64
-            cibw_build: cp3{11,12,13,14}
-            cibw_pre_abi3_build: cp311
+            cibw_build: "cp311-* cp312-* cp313-* cp314-*"
+            cibw_pre_abi3_build: "cp311-*"
             wheel_platform: win_arm64
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -150,7 +150,7 @@ jobs:
             }
             else
             {
-              $Env:CIBW_BUILD = "$Env:CIBW_PRE_ABI3_BUILD-$Env:WHEEL_PLATFORM"
+              $Env:CIBW_BUILD = $Env:CIBW_PRE_ABI3_BUILD
               cibuildwheel .
 
               $Env:CIBW_BUILD = "cp312-$Env:WHEEL_PLATFORM"
@@ -166,7 +166,7 @@ jobs:
             }
             else
             {
-              $Env:CIBW_BUILD = "$Env:CIBW_DEFAULT_BUILD-$Env:WHEEL_PLATFORM"
+              $Env:CIBW_BUILD = $Env:CIBW_DEFAULT_BUILD
             }
 
             if (Test-Path -Path setup.py)


### PR DESCRIPTION
This pull request updates the `build-triton` GitHub Actions workflow to add support for building and packaging Triton wheels for both x64 and arm64 architectures on Windows. The changes introduce a build matrix, generalize environment variables and artifact paths for multi-architecture support, and ensure correct configuration for each architecture.

**Multi-architecture build support:**

* Added a build matrix to the `build-triton` job, enabling builds for both `x64` (on `windows-2022`) and `arm64` (on `windows-11-arm`), with architecture-specific environment variables and build configurations. The job name and runner selection now reflect the current architecture.
* Updated Python and MSVC setup steps to use the correct architecture from the build matrix, ensuring the build environment matches the target architecture.

**Environment variable and build configuration improvements:**

* Generalized environment variables such as `CIBW_ARCHS`, `CIBW_DEFAULT_BUILD`, `CIBW_PRE_ABI3_BUILD`, and `WHEEL_PLATFORM` to use matrix values, allowing the build scripts and `cibuildwheel` commands to work for both x64 and arm64.
* Updated PowerShell scripts to use these generalized environment variables when setting `CIBW_BUILD` for both pre-ABI3 and stable ABI builds, improving maintainability and reducing hardcoding. [[1]](diffhunk://#diff-8e59a769ef5058b609b815f6ea49a76f296aee3d32024768bd4af39794caf273L128-R156) [[2]](diffhunk://#diff-8e59a769ef5058b609b815f6ea49a76f296aee3d32024768bd4af39794caf273L144-R169)

**Artifact upload adjustments:**

* Modified artifact upload steps to use the correct wheel file patterns based on the current architecture, ensuring that the right wheel files are uploaded for both x64 and arm64 builds.