### PR TITLE
Add triton_key() compatibility shim for PyTorch Inductor

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -17,6 +17,18 @@ import os
 import time
 import copy
 
+
+# --- Shim for PyTorch Inductor compatibility ---
+# PyTorch's torch._inductor.codecache and torch._inductor.async_compile import
+# `triton_key` from this module, but it was removed/renamed in Triton 3.x
+# (replaced by `runtime.cache.get_cache_key` with a different signature).
+# Provide a simple version-based cache key so torch.compile works out of the box
+# with triton-windows + recent PyTorch releases.
+def triton_key() -> str:
+    """Return a stable cache-invalidation key for the installed Triton version."""
+    return __version__
+
+
 # - ^\s*tt\.func\s+ : match the start of the string, any leading whitespace, the keyword func,
 #    and any following whitespace
 # - (public\s+)? : optionally match the keyword public and any following whitespace


### PR DESCRIPTION
## Summary

PyTorch's `torch._inductor.codecache` and `torch._inductor.async_compile` import `triton_key` from `triton.compiler.compiler` to generate cache-invalidation keys. This function was removed/renamed in Triton 3.x (replaced by `runtime.cache.get_cache_key` with a different signature), causing `ImportError` when using `torch.compile` with triton-windows on PyTorch 2.7+.

This PR adds a minimal compatibility shim that returns `__version__` as the cache key, matching the original behavior and unblocking `torch.compile` out of the box on Windows.

## Problem

```python
# torch/_inductor/codecache.py does:
from triton.compiler.compiler import triton_key
triton_version = triton_key()

# and torch/_inductor/async_compile.py does the same.
# Both fail with:
#   ImportError: cannot import name 'triton_key'
#     from 'triton.compiler.compiler'
```

This breaks `torch.compile` for all Windows users on recent triton-windows + PyTorch 2.7+. Reported previously in woct0rdho/triton-windows#158.

## Fix

Add a simple `triton_key()` function to `python/triton/compiler/compiler.py` that returns `__version__` — matching the original semantics (a cache-invalidation key that changes with the Triton version).

```python
def triton_key() -> str:
    """Return a stable cache-invalidation key for the installed Triton version."""
    return __version__
```

## Testing

Verified on Windows 11 with:
- triton-windows `3.8.0.post28`
- PyTorch `2.7` (CUDA 12.8)
- NVIDIA RTX 5090 (Blackwell, sm120)
- `torch.compile(transformer, mode="reduce-overhead")` on an LTX-Video diffusion transformer

Before this fix: `ImportError: cannot import name 'triton_key' ...` blocked compilation entirely.
After this fix: `torch.compile` succeeds, first-run warmup completes cleanly, and per-step latency drops by ~77% on our workload (~150s → ~33s per generation).

## Impact

- Adds a single new public symbol; no existing behavior changes.
- Zero risk to Linux users (same file path, additive change).
- Fixes `torch.compile` for all triton-windows users on PyTorch 2.7+.

Happy to iterate on naming/placement if maintainers prefer a different approach (e.g. re-export from `__init__.py`, or wire through `get_cache_key`).
